### PR TITLE
fix: update hexabot helper chatgpt version

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "release:minor": "npm version minor && git push origin main --tags"
   },
   "dependencies": {
-    "hexabot-helper-chatgpt": "^2.1.0"
+    "hexabot-helper-chatgpt": "^2.2.0"
   },
   "author": "Hexastack",
   "license": "AGPL-3.0-only"


### PR DESCRIPTION
# Motivation
The main motivation of this PR is to update the helper dependency version to use hexabot-helper-chatgpt v2.2.0